### PR TITLE
Added the new params for bar-simple and line charts

### DIFF
--- a/schemae/bar-simple.schema.json
+++ b/schemae/bar-simple.schema.json
@@ -23,6 +23,36 @@
       "title": "Description",
       "description": "Chart description (caption) explaining what the chart is showing. Will display as a heading before the chart graphic."
     },
+    "chartHeight": {
+      "type": "number",
+      "title": "Chart height",
+      "description": "Height of the chart as percentage of its width (i.e. 120 will make the chart taller than it's wide)",
+      "default": 80
+    },
+    "range": {
+      "type": "number",
+      "title": "Data range",
+      "description": "[optional] the maximum value shown by the gridlines of the chart. Defaults to the maximum value in the dataset."
+    },
+    "gridLinesCount": {
+      "type": "number",
+      "title": "Number of gridlines",
+      "format": "number",
+      "description": "Number of horizontal grid lines with matching y-axis labels.",
+      "default": 5
+    },
+    "yLabel": {
+      "type": "string",
+      "title": "Y-axis Label",
+      "description": "(optional) Appears on the left side of the chart"
+    },
+    "xLabelInterval": {
+      "type": "number",
+      "title": "X-axis label interval",
+      "format": "number",
+      "description": "(optional) For large datasets, this overrides the interval between displayed x-axis labels. For instance, if interval=5, then every 5th label is shown. If the value is 0, the interval will be chosen automatically (recommended).",
+      "default": 0
+    },
     "value": {
       "type": "array",
       "title": "Chart data",

--- a/schemae/line.schema.json
+++ b/schemae/line.schema.json
@@ -41,6 +41,11 @@
       "description": "Number of horizontal grid lines with matching y-axis labels.",
       "default": 5
     },
+    "yLabel": {
+      "type": "string",
+      "title": "Y-axis Label",
+      "description": "(optional) Appears on the left side of the chart"
+    },
     "fontSize": {
       "type": "number",
       "title": "Labels font size",
@@ -54,6 +59,13 @@
       "format": "color",
       "description": "Doesn't apply to data labels",
       "default": "rgba(0,0,0,0.3)"
+    },
+    "xLabelInterval": {
+      "type": "number",
+      "title": "X-axis label interval",
+      "format": "number",
+      "description": "(optional) For large datasets, this overrides the interval between displayed x-axis labels. For instance, if interval=5, then every 5th label is shown. If the value is 0, the interval will be chosen automatically (recommended).",
+      "default": 0
     },
     "categories": {
       "type": "array",


### PR DESCRIPTION
Authors can now choose an y-axis label and override the automated "cherrypicking" of datapoint labels in large datasets with a custom interval.